### PR TITLE
Update GrumPHP version (requirement)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "phpro/grumphp": "^0.14"
+        "phpro/grumphp": "^0.15"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
There is no backwards compatibility issues, so we can just increase composer version